### PR TITLE
Add the ability to run as a forwarding DNS server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+proxmox-dns-server
+config.json
+.claude/*
+
+CLAUDE.md
+proxmox-dns-server

--- a/config.go
+++ b/config.go
@@ -7,9 +7,19 @@ import (
 	"os"
 )
 
+type StaticRecord struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
+	TTL   uint32 `json:"ttl"`
+}
+
 type Config struct {
-	Zone string `json:"zone"`
-	Port string `json:"port"`
+	Zone          string         `json:"zone"`
+	Port          string         `json:"port"`
+	UpstreamDNS   string         `json:"upstreamDNS,omitempty"`
+	StaticRecords []StaticRecord `json:"staticRecords,omitempty"`
+	RecordsFile   string         `json:"recordsFile,omitempty"`
 }
 
 func LoadConfig() (*Config, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigFromFile(t *testing.T) {
+	dir := t.TempDir()
+
+	recordsPath := filepath.Join(dir, "records.json")
+	recordsContent := map[string]any{
+		"records": []StaticRecord{
+			{Name: "printer", Type: "A", Value: "192.168.1.50", TTL: 600},
+		},
+	}
+	writeJSON(t, recordsPath, recordsContent)
+
+	configPath := filepath.Join(dir, "config.json")
+	cfg := Config{
+		Zone:        "lab.local",
+		Port:        "8053",
+		UpstreamDNS: "127.0.0.1:8600",
+		StaticRecords: []StaticRecord{
+			{Name: "nas", Type: "A", Value: "192.168.1.10", TTL: 300},
+		},
+		RecordsFile: recordsPath,
+	}
+	writeJSON(t, configPath, cfg)
+
+	oldFlags := flag.CommandLine
+	oldArgs := os.Args
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	os.Args = []string{os.Args[0], "-config", configPath}
+	t.Cleanup(func() {
+		flag.CommandLine = oldFlags
+		os.Args = oldArgs
+	})
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if loaded.Zone != "lab.local" {
+		t.Fatalf("expected zone lab.local, got %s", loaded.Zone)
+	}
+	if loaded.Port != "8053" {
+		t.Fatalf("expected port 8053, got %s", loaded.Port)
+	}
+	if loaded.UpstreamDNS != "127.0.0.1:8600" {
+		t.Fatalf("unexpected upstream DNS: %s", loaded.UpstreamDNS)
+	}
+	if len(loaded.StaticRecords) != 1 {
+		t.Fatalf("expected 1 inline record, got %d", len(loaded.StaticRecords))
+	}
+	if loaded.RecordsFile != recordsPath {
+		t.Fatalf("expected records file %s, got %s", recordsPath, loaded.RecordsFile)
+	}
+}
+
+func TestLoadConfigRequiresZone(t *testing.T) {
+	oldFlags := flag.CommandLine
+	oldArgs := os.Args
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	os.Args = []string{os.Args[0]}
+	t.Cleanup(func() {
+		flag.CommandLine = oldFlags
+		os.Args = oldArgs
+	})
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatalf("expected error when zone is missing")
+	}
+}
+
+func writeJSON(t *testing.T, path string, value any) {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}

--- a/dns_server.go
+++ b/dns_server.go
@@ -12,34 +12,43 @@ import (
 type DNSServer struct {
 	zone     string
 	proxmox  *ProxmoxManager
+	static   *StaticRecordManager
+	upstream *UpstreamClient
 	server   *dns.Server
 	port     string
 }
 
-func NewDNSServer(zone, port string) *DNSServer {
+func NewDNSServer(config *Config) *DNSServer {
+	static := NewStaticRecordManager()
+	if err := static.LoadRecords(config); err != nil {
+		log.Printf("Warning: Failed to load static records: %v", err)
+	}
+
 	return &DNSServer{
-		zone:    zone,
-		proxmox: NewProxmoxManager(),
-		port:    port,
+		zone:     config.Zone,
+		proxmox:  NewProxmoxManager(),
+		static:   static,
+		upstream: NewUpstreamClient(config.UpstreamDNS),
+		port:     config.Port,
 	}
 }
 
 func (ds *DNSServer) Start() error {
 	log.Printf("Starting DNS server for zone %s on port %s", ds.zone, ds.port)
-	
+
 	if err := ds.proxmox.RefreshInstances(); err != nil {
 		log.Printf("Warning: Failed to refresh instances on startup: %v", err)
 	}
-	
+
 	go ds.periodicRefresh()
-	
+
 	dns.HandleFunc(ds.zone, ds.handleDNSRequest)
-	
+
 	ds.server = &dns.Server{
 		Addr: ":" + ds.port,
 		Net:  "udp",
 	}
-	
+
 	return ds.server.ListenAndServe()
 }
 
@@ -53,7 +62,7 @@ func (ds *DNSServer) Stop() error {
 func (ds *DNSServer) periodicRefresh() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
-	
+
 	for range ticker.C {
 		if err := ds.proxmox.RefreshInstances(); err != nil {
 			log.Printf("Failed to refresh instances: %v", err)
@@ -65,57 +74,91 @@ func (ds *DNSServer) handleDNSRequest(w dns.ResponseWriter, r *dns.Msg) {
 	m := new(dns.Msg)
 	m.SetReply(r)
 	m.Authoritative = true
-	
+
 	clientAddr := w.RemoteAddr().String()
-	
+	found := false
+
 	for _, q := range r.Question {
 		log.Printf("DNS Request from %s: %s %s", clientAddr, dns.TypeToString[q.Qtype], q.Name)
-		
-		if q.Qtype == dns.TypeA && strings.HasSuffix(q.Name, ds.zone+".") {
-			if answer := ds.resolveA(q.Name); answer != nil {
-				m.Answer = append(m.Answer, answer)
-			} else {
-				log.Printf("DNS Request failed: No record found for %s", q.Name)
-				m.SetRcode(r, dns.RcodeNameError)
+
+		if strings.HasSuffix(q.Name, ds.zone+".") {
+			if answers := ds.resolveQuery(q.Name, dns.TypeToString[q.Qtype]); len(answers) > 0 {
+				m.Answer = append(m.Answer, answers...)
+				found = true
 			}
 		} else {
-			log.Printf("DNS Request failed: Unsupported query type %s or wrong zone for %s", dns.TypeToString[q.Qtype], q.Name)
-			m.SetRcode(r, dns.RcodeNameError)
+			if ds.upstream != nil && ds.upstream.IsConfigured() {
+				if upstreamResp := ds.upstream.Query(r); upstreamResp != nil {
+					w.WriteMsg(upstreamResp)
+					return
+				}
+			}
 		}
 	}
-	
+
+	if !found {
+		log.Printf("DNS Request failed: No record found for any question")
+		m.SetRcode(r, dns.RcodeNameError)
+	}
+
 	w.WriteMsg(m)
 }
 
-func (ds *DNSServer) resolveA(name string) dns.RR {
+func (ds *DNSServer) resolveQuery(name, qtype string) []dns.RR {
 	name = strings.TrimSuffix(name, ".")
 	zoneSuffix := "." + ds.zone
-	
+
 	if !strings.HasSuffix(name, zoneSuffix) {
 		log.Printf("Debug: %s does not match zone %s", name, ds.zone)
 		return nil
 	}
-	
+
+	identifier := strings.TrimSuffix(name, zoneSuffix)
+	log.Printf("Debug: Looking up identifier '%s' for %s %s", identifier, name, qtype)
+
+	if staticAnswers := ds.static.ResolveRecord(identifier, name, qtype); len(staticAnswers) > 0 {
+		log.Printf("Found %d static record(s) for %s", len(staticAnswers), identifier)
+		return staticAnswers
+	}
+
+	if qtype == "A" {
+		if answer := ds.resolveProxmoxA(name); answer != nil {
+			return []dns.RR{answer}
+		}
+	}
+
+	return nil
+}
+
+func (ds *DNSServer) resolveProxmoxA(name string) dns.RR {
+	name = strings.TrimSuffix(name, ".")
+	zoneSuffix := "." + ds.zone
+
+	if !strings.HasSuffix(name, zoneSuffix) {
+		log.Printf("Debug: %s does not match zone %s", name, ds.zone)
+		return nil
+	}
+
 	identifier := strings.TrimSuffix(name, zoneSuffix)
 	log.Printf("Debug: Looking up identifier '%s' for %s", identifier, name)
-	
+
 	instance, exists := ds.proxmox.GetInstanceByIdentifier(identifier)
 	if !exists {
 		log.Printf("Debug: No instance found for identifier '%s'", identifier)
 		return nil
 	}
-	
+
 	if instance.IPv4 == "" {
 		log.Printf("Debug: Instance %s (%s) has no IPv4 address", instance.Name, identifier)
 		return nil
 	}
-	
+
 	ip := net.ParseIP(instance.IPv4)
 	if ip == nil {
 		log.Printf("Debug: Invalid IP address '%s' for instance %s", instance.IPv4, instance.Name)
 		return nil
 	}
-	
+
 	rr := &dns.A{
 		Hdr: dns.RR_Header{
 			Name:   name + ".",
@@ -125,7 +168,7 @@ func (ds *DNSServer) resolveA(name string) dns.RR {
 		},
 		A: ip,
 	}
-	
+
 	log.Printf("Successfully resolved %s to %s (instance: %s, type: %s)", name, instance.IPv4, instance.Name, instance.Type)
 	return rr
 }

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func TestDNSServerHandlesStaticRecord(t *testing.T) {
+	cfg := &Config{
+		Zone: "home.local",
+		Port: "1053",
+		StaticRecords: []StaticRecord{{
+			Name:  "nas",
+			Type:  "A",
+			Value: "192.168.1.10",
+			TTL:   180,
+		}},
+	}
+
+	server := NewDNSServer(cfg)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("nas.home.local.", dns.TypeA)
+
+	writer := newTestResponseWriter()
+	server.handleDNSRequest(writer, msg)
+
+	if writer.msg == nil {
+		t.Fatalf("expected response message")
+	}
+	if len(writer.msg.Answer) != 1 {
+		t.Fatalf("expected one answer, got %d", len(writer.msg.Answer))
+	}
+	a, ok := writer.msg.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("expected A record, got %T", writer.msg.Answer[0])
+	}
+	if a.A.String() != "192.168.1.10" {
+		t.Fatalf("unexpected IP %s", a.A.String())
+	}
+	if a.Hdr.Name != "nas.home.local." {
+		t.Fatalf("unexpected owner name %s", a.Hdr.Name)
+	}
+	if writer.msg.Rcode != dns.RcodeSuccess {
+		t.Fatalf("expected success rcode, got %d", writer.msg.Rcode)
+	}
+}
+
+func TestDNSServerFallsBackToProxmox(t *testing.T) {
+	cfg := &Config{Zone: "home.local", Port: "1053"}
+	server := NewDNSServer(cfg)
+	server.static = NewStaticRecordManager() // ensure empty
+	server.proxmox.instances["app"] = ProxmoxInstance{
+		ID:     101,
+		Name:   "app",
+		Status: "running",
+		Type:   "vm",
+		IPv4:   "192.168.1.30",
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("app.home.local.", dns.TypeA)
+
+	writer := newTestResponseWriter()
+	server.handleDNSRequest(writer, msg)
+
+	if writer.msg == nil {
+		t.Fatalf("expected response from proxmox lookup")
+	}
+	if len(writer.msg.Answer) != 1 {
+		t.Fatalf("expected one answer, got %d", len(writer.msg.Answer))
+	}
+	a, ok := writer.msg.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("expected A record, got %T", writer.msg.Answer[0])
+	}
+	if a.A.String() != "192.168.1.30" {
+		t.Fatalf("unexpected IP %s", a.A.String())
+	}
+}
+
+func TestDNSServerForwardsToUpstream(t *testing.T) {
+	addr := startAuthoritativeDNSServer(t)
+
+	cfg := &Config{
+		Zone:        "home.local",
+		Port:        "1053",
+		UpstreamDNS: addr,
+	}
+	server := NewDNSServer(cfg)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.org.", dns.TypeA)
+
+	writer := newTestResponseWriter()
+	server.handleDNSRequest(writer, msg)
+
+	if writer.msg == nil {
+		t.Fatalf("expected upstream response")
+	}
+	if len(writer.msg.Answer) != 1 {
+		t.Fatalf("expected 1 upstream answer, got %d", len(writer.msg.Answer))
+	}
+	if writer.msg.Answer[0].Header().Name != "example.org." {
+		t.Fatalf("unexpected upstream owner %s", writer.msg.Answer[0].Header().Name)
+	}
+}
+
+func TestDNSServerReturnsNXDomainWhenMissing(t *testing.T) {
+	cfg := &Config{Zone: "home.local", Port: "1053"}
+	server := NewDNSServer(cfg)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("missing.home.local.", dns.TypeA)
+
+	writer := newTestResponseWriter()
+	server.handleDNSRequest(writer, msg)
+
+	if writer.msg == nil {
+		t.Fatalf("expected NXDOMAIN response")
+	}
+	if writer.msg.Rcode != dns.RcodeNameError {
+		t.Fatalf("expected NXDOMAIN, got %d", writer.msg.Rcode)
+	}
+}
+
+func startAuthoritativeDNSServer(t *testing.T) string {
+	t.Helper()
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		rr, err := dns.NewRR("example.org. 300 IN A 203.0.113.5")
+		if err != nil {
+			t.Fatalf("failed to build RR: %v", err)
+		}
+		m.Answer = append(m.Answer, rr)
+		if err := w.WriteMsg(m); err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	})
+
+	server := &dns.Server{Handler: mux}
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	server.PacketConn = pc
+
+	go func() {
+		_ = server.ActivateAndServe()
+	}()
+
+	// Give the server a moment to start.
+	time.Sleep(50 * time.Millisecond)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.ShutdownContext(ctx)
+	})
+
+	return pc.LocalAddr().String()
+}

--- a/dns_test_helpers_test.go
+++ b/dns_test_helpers_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net"
+
+	"github.com/miekg/dns"
+)
+
+type testResponseWriter struct {
+	msg        *dns.Msg
+	remoteAddr net.Addr
+}
+
+func newTestResponseWriter() *testResponseWriter {
+	return &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345},
+	}
+}
+
+func (w *testResponseWriter) WriteMsg(m *dns.Msg) error {
+	w.msg = m.Copy()
+	return nil
+}
+
+func (w *testResponseWriter) Write([]byte) (int, error) {
+	return 0, nil
+}
+
+func (w *testResponseWriter) Close() error { return nil }
+
+func (w *testResponseWriter) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 53}
+}
+
+func (w *testResponseWriter) RemoteAddr() net.Addr {
+	return w.remoteAddr
+}
+
+func (w *testResponseWriter) TsigStatus() error { return nil }
+
+func (w *testResponseWriter) TsigTimersOnly(bool) {}
+
+func (w *testResponseWriter) Hijack() {}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 		os.Exit(1)
 	}
 	
-	server := NewDNSServer(config.Zone, config.Port)
+	server := NewDNSServer(config)
 	
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
@@ -43,7 +43,7 @@ func main() {
 		os.Exit(0)
 	}()
 	
-	log.Printf("Starting Proxmox DNS server for zone %s on port %s", config.Zone, config.Port)
+	log.Printf("Starting general-purpose DNS server for zone %s on port %s", config.Zone, config.Port)
 	if err := server.Start(); err != nil {
 		log.Fatalf("Failed to start DNS server: %v", err)
 	}

--- a/proxmox_test.go
+++ b/proxmox_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestProxmoxManagerFilterIPv4(t *testing.T) {
+	pm := NewProxmoxManager()
+	ip, err := pm.filterIPv4("10.0.0.1 192.168.1.99 fe80::1")
+	if err != nil {
+		t.Fatalf("expected IPv4 match, got error %v", err)
+	}
+	if ip != "192.168.1.99" {
+		t.Fatalf("expected 192.168.1.99, got %s", ip)
+	}
+
+	if _, err := pm.filterIPv4("10.0.0.1"); err == nil {
+		t.Fatalf("expected error when no suitable IPv4 present")
+	}
+}
+
+func TestProxmoxManagerGetInstanceByIdentifier(t *testing.T) {
+	pm := NewProxmoxManager()
+	instance := ProxmoxInstance{ID: 101, Name: "app", IPv4: "192.168.1.30"}
+	pm.instances["app"] = instance
+
+	got, ok := pm.GetInstanceByIdentifier("app")
+	if !ok {
+		t.Fatalf("expected to find instance")
+	}
+	if got.IPv4 != "192.168.1.30" {
+		t.Fatalf("unexpected IPv4 %s", got.IPv4)
+	}
+}

--- a/static_records.go
+++ b/static_records.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/miekg/dns"
+)
+
+type StaticRecordManager struct {
+	records map[string][]StaticRecord
+	mutex   sync.RWMutex
+}
+
+type RecordsFile struct {
+	Records []StaticRecord `json:"records"`
+}
+
+func NewStaticRecordManager() *StaticRecordManager {
+	return &StaticRecordManager{
+		records: make(map[string][]StaticRecord),
+	}
+}
+
+func (srm *StaticRecordManager) LoadRecords(config *Config) error {
+	srm.mutex.Lock()
+	defer srm.mutex.Unlock()
+
+	srm.records = make(map[string][]StaticRecord)
+
+	for _, record := range config.StaticRecords {
+		if err := srm.validateRecord(&record); err != nil {
+			log.Printf("Warning: Invalid static record %s: %v", record.Name, err)
+			continue
+		}
+		srm.addRecord(record, config.Zone)
+	}
+
+	if config.RecordsFile != "" {
+		if err := srm.loadFromFile(config.RecordsFile, config.Zone); err != nil {
+			return fmt.Errorf("failed to load records file: %v", err)
+		}
+	}
+
+	log.Printf("Loaded %d static record entries", len(srm.records))
+	return nil
+}
+
+func (srm *StaticRecordManager) loadFromFile(filename, zone string) error {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	var recordsFile RecordsFile
+	if err := json.Unmarshal(data, &recordsFile); err != nil {
+		return err
+	}
+
+	for _, record := range recordsFile.Records {
+		if err := srm.validateRecord(&record); err != nil {
+			log.Printf("Warning: Invalid record in file %s: %v", record.Name, err)
+			continue
+		}
+		srm.addRecord(record, zone)
+	}
+
+	return nil
+}
+
+func (srm *StaticRecordManager) addRecord(record StaticRecord, zone string) {
+	primaryKey := normalizeRecordKey(record.Name)
+	if primaryKey == "" {
+		return
+	}
+
+	srm.records[primaryKey] = append(srm.records[primaryKey], record)
+
+	zone = strings.TrimSpace(zone)
+	zone = strings.TrimSuffix(zone, ".")
+	zone = strings.ToLower(zone)
+	if zone == "" {
+		return
+	}
+
+	if strings.Contains(primaryKey, ".") {
+		return
+	}
+
+	fqdnKey := normalizeRecordKey(primaryKey + "." + zone)
+	srm.records[fqdnKey] = append(srm.records[fqdnKey], record)
+}
+
+func normalizeRecordKey(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+
+	name = strings.TrimSuffix(name, ".")
+	return strings.ToLower(name)
+}
+
+func (srm *StaticRecordManager) validateRecord(record *StaticRecord) error {
+	if record.Name == "" {
+		return fmt.Errorf("record name cannot be empty")
+	}
+
+	record.Type = strings.ToUpper(record.Type)
+	switch record.Type {
+	case "A":
+		if net.ParseIP(record.Value) == nil {
+			return fmt.Errorf("invalid IPv4 address: %s", record.Value)
+		}
+	case "AAAA":
+		if net.ParseIP(record.Value) == nil {
+			return fmt.Errorf("invalid IPv6 address: %s", record.Value)
+		}
+	case "CNAME", "TXT":
+		if record.Value == "" {
+			return fmt.Errorf("value cannot be empty for %s record", record.Type)
+		}
+	case "MX":
+		parts := strings.Fields(record.Value)
+		if len(parts) != 2 {
+			return fmt.Errorf("MX record must have format 'priority hostname'")
+		}
+		if _, err := strconv.Atoi(parts[0]); err != nil {
+			return fmt.Errorf("invalid MX priority: %s", parts[0])
+		}
+	default:
+		return fmt.Errorf("unsupported record type: %s", record.Type)
+	}
+
+	if record.TTL == 0 {
+		record.TTL = 300
+	}
+
+	return nil
+}
+
+func (srm *StaticRecordManager) ResolveRecord(identifier, queryName, qtype string) []dns.RR {
+	srm.mutex.RLock()
+	defer srm.mutex.RUnlock()
+
+	lookupKeys := []string{
+		normalizeRecordKey(identifier),
+		normalizeRecordKey(queryName),
+	}
+
+	seen := make(map[string]struct{})
+	var records []StaticRecord
+	for _, key := range lookupKeys {
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		if recs, ok := srm.records[key]; ok {
+			records = append(records, recs...)
+		}
+	}
+
+	if len(records) == 0 {
+		return nil
+	}
+
+	owner := queryName
+	if owner == "" {
+		owner = identifier
+	}
+	owner = dns.Fqdn(owner)
+
+	var answers []dns.RR
+	requestedType := strings.ToUpper(qtype)
+	for _, record := range records {
+		if strings.ToUpper(record.Type) != requestedType {
+			continue
+		}
+
+		rr := srm.createDNSRecord(owner, record)
+		if rr != nil {
+			answers = append(answers, rr)
+		}
+	}
+
+	return answers
+}
+
+func (srm *StaticRecordManager) createDNSRecord(owner string, record StaticRecord) dns.RR {
+	fqdn := dns.Fqdn(owner)
+
+	header := dns.RR_Header{
+		Name:  fqdn,
+		Class: dns.ClassINET,
+		Ttl:   record.TTL,
+	}
+
+	switch strings.ToUpper(record.Type) {
+	case "A":
+		header.Rrtype = dns.TypeA
+		return &dns.A{
+			Hdr: header,
+			A:   net.ParseIP(record.Value),
+		}
+	case "AAAA":
+		header.Rrtype = dns.TypeAAAA
+		return &dns.AAAA{
+			Hdr:  header,
+			AAAA: net.ParseIP(record.Value),
+		}
+	case "CNAME":
+		header.Rrtype = dns.TypeCNAME
+		target := record.Value
+		if !strings.HasSuffix(target, ".") {
+			target += "."
+		}
+		return &dns.CNAME{
+			Hdr:    header,
+			Target: target,
+		}
+	case "TXT":
+		header.Rrtype = dns.TypeTXT
+		return &dns.TXT{
+			Hdr: header,
+			Txt: []string{record.Value},
+		}
+	case "MX":
+		header.Rrtype = dns.TypeMX
+		parts := strings.Fields(record.Value)
+		priority, _ := strconv.Atoi(parts[0])
+		mx := parts[1]
+		if !strings.HasSuffix(mx, ".") {
+			mx += "."
+		}
+		return &dns.MX{
+			Hdr:        header,
+			Preference: uint16(priority),
+			Mx:         mx,
+		}
+	}
+
+	return nil
+}
+
+func (srm *StaticRecordManager) HasRecord(name string) bool {
+	srm.mutex.RLock()
+	defer srm.mutex.RUnlock()
+
+	key := normalizeRecordKey(name)
+	_, exists := srm.records[key]
+	return exists
+}

--- a/static_records.go
+++ b/static_records.go
@@ -155,6 +155,7 @@ func (srm *StaticRecordManager) ResolveRecord(identifier, queryName, qtype strin
 	}
 
 	seen := make(map[string]struct{})
+	seenRecords := make(map[string]struct{})
 	var records []StaticRecord
 	for _, key := range lookupKeys {
 		if key == "" {
@@ -165,7 +166,14 @@ func (srm *StaticRecordManager) ResolveRecord(identifier, queryName, qtype strin
 		}
 		seen[key] = struct{}{}
 		if recs, ok := srm.records[key]; ok {
-			records = append(records, recs...)
+			for _, record := range recs {
+				signature := recordSignature(record)
+				if _, exists := seenRecords[signature]; exists {
+					continue
+				}
+				seenRecords[signature] = struct{}{}
+				records = append(records, record)
+			}
 		}
 	}
 
@@ -258,4 +266,10 @@ func (srm *StaticRecordManager) HasRecord(name string) bool {
 	key := normalizeRecordKey(name)
 	_, exists := srm.records[key]
 	return exists
+}
+
+func recordSignature(record StaticRecord) string {
+	nameKey := normalizeRecordKey(record.Name)
+	typeKey := strings.ToUpper(record.Type)
+	return nameKey + "|" + typeKey + "|" + record.Value + "|" + strconv.FormatUint(uint64(record.TTL), 10)
 }

--- a/static_records_test.go
+++ b/static_records_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestStaticRecordManagerResolveWithShortAndFQDN(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "records.json")
+	writeJSON(t, filePath, map[string]any{
+		"records": []StaticRecord{
+			{Name: "printer", Type: "A", Value: "192.168.1.20", TTL: 450},
+		},
+	})
+
+	manager := NewStaticRecordManager()
+	cfg := &Config{
+		Zone: "home.local",
+		StaticRecords: []StaticRecord{
+			{Name: "nas", Type: "A", Value: "192.168.1.10", TTL: 120},
+		},
+		RecordsFile: filePath,
+	}
+
+	if err := manager.LoadRecords(cfg); err != nil {
+		t.Fatalf("failed to load records: %v", err)
+	}
+
+	tests := []struct {
+		identifier string
+		queryName  string
+		value      string
+		ttl        uint32
+	}{
+		{identifier: "nas", queryName: "nas.home.local", value: "192.168.1.10", ttl: 120},
+		{identifier: "nas.home.local", queryName: "nas.home.local", value: "192.168.1.10", ttl: 120},
+		{identifier: "printer", queryName: "printer.home.local", value: "192.168.1.20", ttl: 450},
+	}
+
+	for _, tc := range tests {
+		answers := manager.ResolveRecord(tc.identifier, tc.queryName, "A")
+		if len(answers) != 1 {
+			t.Fatalf("expected 1 answer for %s/%s got %d", tc.identifier, tc.queryName, len(answers))
+		}
+		a, ok := answers[0].(*dns.A)
+		if !ok {
+			t.Fatalf("expected *dns.A record, got %T", answers[0])
+		}
+		if a.A.String() != tc.value {
+			t.Fatalf("expected IP %s, got %s", tc.value, a.A.String())
+		}
+		if a.Hdr.Name != dns.Fqdn(tc.queryName) {
+			t.Fatalf("unexpected owner name %s", a.Hdr.Name)
+		}
+		if a.Hdr.Ttl != tc.ttl {
+			t.Fatalf("expected TTL %d, got %d", tc.ttl, a.Hdr.Ttl)
+		}
+	}
+}
+
+func TestStaticRecordManagerHasRecordUsesNormalization(t *testing.T) {
+	manager := NewStaticRecordManager()
+	cfg := &Config{
+		Zone: "home.local",
+		StaticRecords: []StaticRecord{
+			{Name: "gateway", Type: "A", Value: "192.168.1.1", TTL: 300},
+		},
+	}
+	if err := manager.LoadRecords(cfg); err != nil {
+		t.Fatalf("failed to load records: %v", err)
+	}
+
+	if !manager.HasRecord("gateway") {
+		t.Fatalf("expected HasRecord to match short name")
+	}
+	if !manager.HasRecord("gateway.home.local.") {
+		t.Fatalf("expected HasRecord to match fully qualified name")
+	}
+	if manager.HasRecord("missing") {
+		t.Fatalf("expected missing record to return false")
+	}
+}

--- a/upstream_client.go
+++ b/upstream_client.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type UpstreamClient struct {
+	server  string
+	client  *dns.Client
+	timeout time.Duration
+}
+
+func NewUpstreamClient(server string) *UpstreamClient {
+	if server == "" {
+		return nil
+	}
+
+	return &UpstreamClient{
+		server: server,
+		client: &dns.Client{
+			Net:     "udp",
+			Timeout: 5 * time.Second,
+		},
+		timeout: 5 * time.Second,
+	}
+}
+
+func (uc *UpstreamClient) Query(r *dns.Msg) *dns.Msg {
+	if uc == nil {
+		return nil
+	}
+
+	log.Printf("Forwarding DNS query to upstream server %s", uc.server)
+
+	resp, _, err := uc.client.Exchange(r, uc.server)
+	if err != nil {
+		log.Printf("Failed to query upstream DNS server %s: %v", uc.server, err)
+		return nil
+	}
+
+	if resp == nil {
+		log.Printf("No response from upstream DNS server %s", uc.server)
+		return nil
+	}
+
+	log.Printf("Received response from upstream server with %d answers", len(resp.Answer))
+	return resp
+}
+
+func (uc *UpstreamClient) IsConfigured() bool {
+	return uc != nil && uc.server != ""
+}

--- a/upstream_client_test.go
+++ b/upstream_client_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestUpstreamClientQuery(t *testing.T) {
+	addr := startAuthoritativeDNSServer(t)
+
+	client := NewUpstreamClient(addr)
+	if client == nil {
+		t.Fatalf("expected client instance")
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.org.", dns.TypeA)
+
+	resp := client.Query(msg)
+	if resp == nil {
+		t.Fatalf("expected response from upstream server")
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(resp.Answer))
+	}
+	if resp.Answer[0].Header().Name != "example.org." {
+		t.Fatalf("unexpected answer name %s", resp.Answer[0].Header().Name)
+	}
+}
+
+func TestUpstreamClientIsConfigured(t *testing.T) {
+	if client := NewUpstreamClient(""); client != nil {
+		t.Fatalf("expected nil client when no server configured")
+	}
+
+	client := NewUpstreamClient("127.0.0.1:53")
+	if client == nil {
+		t.Fatalf("expected client when server provided")
+	}
+	if !client.IsConfigured() {
+		t.Fatalf("expected IsConfigured to return true")
+	}
+}


### PR DESCRIPTION
For the records that are not part of Proxmox, this becomes a general purpose DNS server with forwarding functionality. With this, we can now just set this as the default DNS server at home.